### PR TITLE
Force dark mode

### DIFF
--- a/src/me3_manager/main.py
+++ b/src/me3_manager/main.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QApplication
 
 from me3_manager.ui.main_window import ModEngine3Manager
@@ -69,8 +70,10 @@ def main():
     app.setApplicationName("Mod Engine 3 Manager")
     app.setOrganizationName("ME3 Tools")
 
-    # Apply dark theme
     app.setStyle("Fusion")
+
+    # Force dark mode
+    app.styleHints().setColorScheme(Qt.ColorScheme.Dark)
 
     # Create and show main window
     window = ModEngine3Manager()


### PR DESCRIPTION
Fixes #44 

[Fusion style](https://doc.qt.io/qtforpython-6/overviews/qtquickcontrols-fusion.html#fusion-style) technically has both light and dark themes.

At this point, `app.styleHints().colorScheme()` may be one of `Qt.ColorScheme.Light`, `Qt.ColorScheme.Dark`, or `Qt.ColorScheme.Unknown` depending on the user's system settings.

`setColorScheme()` gives a hint to the system that our app is supposed to be dark mode. This fixes unreadable link text on some platforms (Xfce).

https://doc.qt.io/qtforpython-6/PySide6/QtGui/QStyleHints.html#PySide6.QtGui.QStyleHints.colorScheme