### PR TITLE
fix: Enforce unique mod folders for profiles

### DIFF
--- a/resources/translations/ar.json
+++ b/resources/translations/ar.json
@@ -351,6 +351,8 @@
   "new_profile_name_title": "اسم البروفايل الجديد",
   "new_profile_name_desc": "أدخل اسم للبروفايل الجديد:",
   "select_folder_for_profile_title": "اختر مجلد للبروفايل الجديد",
+  "folder_in_use_desc": "المجلد \"{folder_name}\" مستخدم من بروفايل ثاني.\n\nكل بروفايل لازم يكون له مجلد خاص للمودات حقته.\n\nالرجاء اختيار أو إنشاء مجلد مختلف.",
+  "folder_in_use_title": "المجلد مستخدم",
   "rename_profile_title": "إعادة تسمية البروفايل",
   "enter_new_name_desc": "أدخل الاسم الجديد:",
   "confirm_delete_title": "تأكيد الحذف",

--- a/resources/translations/en.json
+++ b/resources/translations/en.json
@@ -351,6 +351,8 @@
   "new_profile_name_title": "New Profile Name",
   "new_profile_name_desc": "Enter a name for the new profile:",
   "select_folder_for_profile_title": "Select a Folder for the New Profile",
+  "folder_in_use_desc": "The selected folder {folder_name} is already being used by another profile.\n\nEach profile must have its own unique folder for its mods.\n\nPlease choose or create a different folder.",
+  "folder_in_use_title": "Folder Already in Use",
   "rename_profile_title": "Rename Profile",
   "enter_new_name_desc": "Enter new name:",
   "confirm_delete_title": "Confirm Delete",

--- a/resources/translations/zh.json
+++ b/resources/translations/zh.json
@@ -351,6 +351,8 @@
   "new_profile_name_title": "新配置文件名称",
   "new_profile_name_desc": "输入新配置文件的名称:",
   "select_folder_for_profile_title": "为新配置文件选择文件夹",
+  "folder_in_use_desc": "所选文件夹“{folder_name}”已被另一个配置文件使用。\n\n每个配置文件都必须拥有其独立的模组文件夹。\n\n请选择或创建一个不同的文件夹。",
+  "folder_in_use_title": "文件夹已被使用",
   "rename_profile_title": "重命名配置文件",
   "enter_new_name_desc": "输入新名称:",
   "confirm_delete_title": "确认删除",


### PR DESCRIPTION
Prevent users from creating a new profile in a mods folder that is already in use by another profile.

Previously, selecting an existing mods folder would cause multiple profiles to share the same directory, leading to mod cross-contamination and incorrect behavior when adding or deleting mods.

This change adds a validation step that checks the selected folder against all existing profile paths for the current game. If a conflict is detected, the user is shown an error message and the profile is not created.