### PR TITLE
feat(windows): route updates for portable ME3 to ZIP installer

### DIFF
--- a/src/me3_manager/ui/main_window.py
+++ b/src/me3_manager/ui/main_window.py
@@ -197,7 +197,8 @@ class ModEngine3Manager(QMainWindow):
 
             if reply == QMessageBox.StandardButton.Yes:
                 if sys.platform == "win32":
-                    self.version_manager.download_windows_installer()
+                    # Route via version manager so portable installs use ZIP replacement
+                    self.version_manager.update_me3_cli()
                 else:
                     self.version_manager.install_linux_me3()
 


### PR DESCRIPTION
- Detect portable install via PathManager.get_me3_binary_path() and installation_prefix.
- In ME3VersionManager.update_me3_cli(), call custom_install_windows_me3() when portable on Windows.
- Startup update prompt now calls version_manager.update_me3_cli() so portable routing is respected.
- Add shutil import for PATH detection