### PR TITLE
Prevent crash when adding a profile on Linux

### DIFF
--- a/resources/translations/ar.json
+++ b/resources/translations/ar.json
@@ -359,6 +359,7 @@
   "new_profile_name_title": "اسم البروفايل الجديد",
   "new_profile_name_desc": "أدخل اسم للبروفايل الجديد:",
   "select_folder_for_profile_title": "اختر مجلد للبروفايل الجديد",
+  "no_folder_selected_msg": "ما تم اختيار أي مجلد. لو سمحت اختر مجلد عشان تسوي البروفايل.",
   "folder_in_use_desc": "المجلد \"{folder_name}\" مستخدم من بروفايل ثاني.\n\nكل بروفايل لازم يكون له مجلد خاص للمودات حقته.\n\nالرجاء اختيار أو إنشاء مجلد مختلف.",
   "folder_in_use_title": "المجلد مستخدم",
   "rename_profile_title": "إعادة تسمية البروفايل",

--- a/resources/translations/en.json
+++ b/resources/translations/en.json
@@ -359,6 +359,7 @@
   "new_profile_name_title": "New Profile Name",
   "new_profile_name_desc": "Enter a name for the new profile:",
   "select_folder_for_profile_title": "Select a Folder for the New Profile",
+  "no_folder_selected_msg": "No folder was selected. Please choose a folder to create the profile.",
   "folder_in_use_desc": "The selected folder {folder_name} is already being used by another profile.\n\nEach profile must have its own unique folder for its mods.\n\nPlease choose or create a different folder.",
   "folder_in_use_title": "Folder Already in Use",
   "rename_profile_title": "Rename Profile",

--- a/resources/translations/zh.json
+++ b/resources/translations/zh.json
@@ -359,6 +359,7 @@
   "new_profile_name_title": "新配置文件名称",
   "new_profile_name_desc": "输入新配置文件的名称:",
   "select_folder_for_profile_title": "为新配置文件选择文件夹",
+  "no_folder_selected_msg": "未选择任何文件夹。请选择一个文件夹来创建配置文件。",
   "folder_in_use_desc": "所选文件夹“{folder_name}”已被另一个配置文件使用。\n\n每个配置文件都必须拥有其独立的模组文件夹。\n\n请选择或创建一个不同的文件夹。",
   "folder_in_use_title": "文件夹已被使用",
   "rename_profile_title": "重命名配置文件",

--- a/src/me3_manager/ui/game_page_components/profile_handler.py
+++ b/src/me3_manager/ui/game_page_components/profile_handler.py
@@ -213,11 +213,16 @@ class ProfileHandler:
                     all_profiles = self.config_manager.get_profiles_for_game(
                         self.game_name
                     )
-                    existing_mod_paths = {
-                        Path(p["mods_path"]).resolve()
-                        for p in all_profiles
-                        if "mods_path" in p
-                    }
+                    # Build a set of existing mod directories, skipping any invalid/None entries
+                    existing_mod_paths = set()
+                    for p in all_profiles:
+                        raw_mods_path = p.get("mods_path")
+                        if isinstance(raw_mods_path, str) and raw_mods_path.strip():
+                            try:
+                                existing_mod_paths.add(Path(raw_mods_path).resolve())
+                            except Exception:
+                                # Skip malformed paths silently
+                                pass
 
                     if selected_path in existing_mod_paths:
                         QMessageBox.warning(
@@ -252,6 +257,12 @@ class ProfileHandler:
                         return
 
                     refresh_list()
+                else:
+                    QMessageBox.information(
+                        dialog,
+                        tr("validation_error"),
+                        tr("no_folder_selected_msg"),
+                    )
 
         def on_rename():
             selected_item = list_widget.currentItem()


### PR DESCRIPTION

- Fixed a crash in the add-profile flow caused by legacy profiles with `mods_path=None` (avoids Path(None) TypeError).
- Skips invalid/None mods_path entries when checking for folder conflicts.
- Shows an information message if the folder dialog is closed without selecting a folder.
- Added translation key no_folder_selected_msg to en/ar/zh for consistent UX. Impact:

Impact:
- Profile creation now works reliably on Linux.
- Users get clear feedback when they cancel the folder selection.