### PR TITLE
Add default installer path for ME3 executable in platform_utils.py

### DIFF
--- a/src/me3_manager/utils/platform_utils.py
+++ b/src/me3_manager/utils/platform_utils.py
@@ -107,6 +107,15 @@ class PlatformUtils:
                 candidates.append(
                     Path(localappdata) / "garyttierney" / "me3" / "bin" / "me3.exe"
                 )
+                # Also consider default installer path under Local\\Programs
+                candidates.append(
+                    Path(localappdata)
+                    / "Programs"
+                    / "garyttierney"
+                    / "me3"
+                    / "bin"
+                    / "me3.exe"
+                )
 
             # 3) Fallback based on HOME path
             home = Path.home()


### PR DESCRIPTION
Updated the PlatformUtils class to include an additional candidate path for the ME3 executable, specifically under the `Local\\Programs directory`. This enhancement ensures that the application can locate the executable more reliably across different installation scenarios.