### PR TITLE
feat: Add profile comparison dialog

### DIFF
--- a/resources/translations/ar.json
+++ b/resources/translations/ar.json
@@ -427,5 +427,17 @@
   "profile_settings_save_error": "فشل حفظ إعدادات البروفايل: {error}",
   "profile_load_error_msg": "فشل تحميل إعدادات البروفايل: {error}",
   "add_to_steam_button": "أضف البروفايل لستيم",
-  "add_to_steam_info": "يضيف اختصار لعبة (غير ستيم) لمكتبتك في ستيم يشغّل هالبروفايل عبر ME3. بعد الإضافة، أعد تشغيل ستيم عشان يظهر الاختصار."
+  "add_to_steam_info": "يضيف اختصار لعبة (غير ستيم) لمكتبتك في ستيم يشغّل هالبروفايل عبر ME3. بعد الإضافة، أعد تشغيل ستيم عشان يظهر الاختصار.",
+  "profile_compare_title": "مقارنة البروفايلات - {game_name}",
+  "profile_compare_header": "اختر بروفايلين عشان تقارن الـ DLLs والبكجات المفعّلة.",
+  "profile_compare_side_title": "بروفايل ({side})",
+  "left": "يسار",
+  "right": "يمين",
+  "profile_compare_contents": "محتوى البروفايل",
+  "profile_compare_natives": "الملفات الأصلية (DLLs)",
+  "profile_compare_packages": "البكجات",
+  "profile_compare_differences": "ملخص الفروقات",
+  "profile_compare_added": "+ تمت الإضافة في اليمين: {count}",
+  "profile_compare_removed": "- تم الحذف من اليمين: {count}",
+  "compare_button": "قارن..."
 }

--- a/resources/translations/en.json
+++ b/resources/translations/en.json
@@ -428,4 +428,17 @@
   "profile_load_error_msg": "Failed to load profile settings: {error}",
   "add_to_steam_button": "Add profile to Steam",
   "add_to_steam_info": "Adds a non-Steam shortcut to your Steam library that launches this game's current profile via ME3. Restart Steam to see the shortcut."
+  ,
+  "profile_compare_title": "Compare Profiles - {game_name}",
+  "profile_compare_header": "Select two profiles to compare their enabled DLLs and packages.",
+  "profile_compare_side_title": "Profile ({side})",
+  "left": "Left",
+  "right": "Right",
+  "profile_compare_contents": "Profile Contents",
+  "profile_compare_natives": "Natives (DLLs)",
+  "profile_compare_packages": "Packages",
+  "profile_compare_differences": "Differences Summary",
+  "profile_compare_added": "+ Added in Right: {count}",
+  "profile_compare_removed": "- Removed from Right: {count}",
+  "compare_button": " Compare..."
 }

--- a/resources/translations/zh.json
+++ b/resources/translations/zh.json
@@ -427,5 +427,17 @@
   "profile_settings_save_error": "保存配置文件设置失败: {error}",
   "profile_load_error_msg": "加载配置文件设置失败: {error}",
   "add_to_steam_button": "添加配置到 Steam",
-  "add_to_steam_info": "将此配置作为非 Steam 游戏快捷方式添加到您的 Steam 库，并通过 ME3 启动。添加后请重启 Steam 以显示快捷方式。"
+  "add_to_steam_info": "将此配置作为非 Steam 游戏快捷方式添加到您的 Steam 库，并通过 ME3 启动。添加后请重启 Steam 以显示快捷方式。",
+  "profile_compare_title": "比较配置文件 - {game_name}",
+  "profile_compare_header": "选择两个配置文件以比较它们启用的 DLL 和包。",
+  "profile_compare_side_title": "配置文件 ({side})",
+  "left": "左侧",
+  "right": "右侧",
+  "profile_compare_contents": "配置文件内容",
+  "profile_compare_natives": "原生文件 (DLL)",
+  "profile_compare_packages": "包 (Packages)",
+  "profile_compare_differences": "差异摘要",
+  "profile_compare_added": "+ 右侧新增: {count}",
+  "profile_compare_removed": "- 右侧移除: {count}",
+  "compare_button": "比较..."
 }

--- a/src/me3_manager/ui/dialogs/profile_compare_dialog.py
+++ b/src/me3_manager/ui/dialogs/profile_compare_dialog.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
+
+from me3_manager.utils.translator import tr
+
+
+class ProfileCompareDialog(QDialog):
+    """Side-by-side comparison of two profiles for a game."""
+
+    def __init__(self, game_name: str, config_manager, parent=None):
+        super().__init__(parent)
+        self.game_name = game_name
+        self.config_manager = config_manager
+        self.setWindowTitle(tr("profile_compare_title", game_name=game_name))
+        self.setMinimumSize(900, 550)
+        self.setStyleSheet(
+            """
+            QDialog { background-color: #1e1e1e; color: #ffffff; }
+            QLabel { background-color: transparent; }
+            QListWidget { background-color: #252525; border: 1px solid #3d3d3d; border-radius: 6px; }
+            QGroupBox { border: 1px solid #3d3d3d; border-radius: 6px; margin-top: 12px; }
+            QGroupBox::title { subcontrol-origin: margin; left: 10px; padding: 0 4px; }
+            QPushButton { background-color: #2d2d2d; border: 1px solid #3d3d3d; padding: 8px 14px; border-radius: 6px; }
+            QPushButton:hover { background-color: #3d3d3d; }
+            #DiffAdded { color: #6CC04A; }
+            #DiffRemoved { color: #E05D5D; }
+            #Header { font-weight: bold; }
+            QFrame#line { background-color: #3d3d3d; }
+            """
+        )
+
+        root_layout = QVBoxLayout(self)
+        root_layout.setContentsMargins(14, 14, 14, 14)
+        root_layout.setSpacing(10)
+
+        header = QLabel(tr("profile_compare_header"))
+        header.setObjectName("Header")
+        root_layout.addWidget(header)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+        splitter.setChildrenCollapsible(False)
+
+        # Left profile selection and contents
+        self.left_box = self._build_profile_panel(side="left")
+        # Right profile selection and contents
+        self.right_box = self._build_profile_panel(side="right")
+
+        splitter.addWidget(self.left_box)
+        splitter.addWidget(self.right_box)
+        splitter.setSizes([450, 450])
+        root_layout.addWidget(splitter)
+
+        # Differences summary
+        self.diff_group = QGroupBox(tr("profile_compare_differences"))
+        diff_layout = QGridLayout(self.diff_group)
+        self.added_label = QLabel(tr("profile_compare_added", count=0))
+        self.added_label.setObjectName("DiffAdded")
+        self.removed_label = QLabel(tr("profile_compare_removed", count=0))
+        self.removed_label.setObjectName("DiffRemoved")
+        diff_layout.addWidget(self.added_label, 0, 0)
+        diff_layout.addWidget(self.removed_label, 0, 1)
+        root_layout.addWidget(self.diff_group)
+
+        # Bottom buttons
+        buttons_layout = QHBoxLayout()
+        buttons_layout.addStretch()
+        close_btn = QPushButton(tr("close_button"))
+        close_btn.clicked.connect(self.accept)
+        buttons_layout.addWidget(close_btn)
+        root_layout.addLayout(buttons_layout)
+
+        # Initialize selection to active profile on the left
+        self._populate_profiles()
+        self._load_selected_profiles()
+
+    def _build_profile_panel(self, side: str) -> QWidget:
+        container = QWidget()
+        v = QVBoxLayout(container)
+        v.setSpacing(8)
+
+        title = QLabel(
+            tr(
+                "profile_compare_side_title",
+                side=tr("left") if side == "left" else tr("right"),
+            )
+        )
+        v.addWidget(title)
+
+        self.__dict__[f"{side}_profiles"] = QListWidget()
+        self.__dict__[f"{side}_profiles"].currentItemChanged.connect(
+            self._load_selected_profiles
+        )
+        v.addWidget(self.__dict__[f"{side}_profiles"])
+
+        group = QGroupBox(tr("profile_compare_contents"))
+        grid = QGridLayout(group)
+        grid.setHorizontalSpacing(10)
+        grid.setVerticalSpacing(6)
+
+        # Natives and Packages lists
+        self.__dict__[f"{side}_natives_list"] = QListWidget()
+        self.__dict__[f"{side}_packages_list"] = QListWidget()
+        grid.addWidget(QLabel(tr("profile_compare_natives")), 0, 0)
+        grid.addWidget(QLabel(tr("profile_compare_packages")), 0, 1)
+        grid.addWidget(self.__dict__[f"{side}_natives_list"], 1, 0)
+        grid.addWidget(self.__dict__[f"{side}_packages_list"], 1, 1)
+
+        v.addWidget(group)
+        return container
+
+    def _populate_profiles(self):
+        profiles = self.config_manager.get_profiles_for_game(self.game_name)
+        active = self.config_manager.get_active_profile(self.game_name)
+        left_widget: QListWidget = self.left_profiles
+        right_widget: QListWidget = self.right_profiles
+        left_widget.clear()
+        right_widget.clear()
+        for p in profiles:
+            item_left = QListWidgetItem(p.get("name", ""))
+            item_left.setData(Qt.ItemDataRole.UserRole, p.get("id"))
+            left_widget.addItem(item_left)
+
+            item_right = QListWidgetItem(p.get("name", ""))
+            item_right.setData(Qt.ItemDataRole.UserRole, p.get("id"))
+            right_widget.addItem(item_right)
+
+        # Preselect active on left, first different on right
+        if active:
+            for i in range(left_widget.count()):
+                if left_widget.item(i).data(Qt.ItemDataRole.UserRole) == active.get(
+                    "id"
+                ):
+                    left_widget.setCurrentRow(i)
+                    break
+        if right_widget.count() > 0:
+            # Choose a different profile if available
+            right_row = 0
+            if active:
+                for i in range(right_widget.count()):
+                    if right_widget.item(i).data(
+                        Qt.ItemDataRole.UserRole
+                    ) != active.get("id"):
+                        right_row = i
+                        break
+            right_widget.setCurrentRow(right_row)
+
+    def _read_profile(self, profile_id: str) -> dict[str, Any]:
+        # Find profile path and read TOML via ProfileManager through facade
+        for p in self.config_manager.get_profiles_for_game(self.game_name):
+            if p.get("id") == profile_id:
+                path = Path(p.get("profile_path", ""))
+                try:
+                    return self.config_manager._parse_toml_config(path)
+                except Exception:
+                    return {"natives": [], "packages": []}
+        return {"natives": [], "packages": []}
+
+    def _load_selected_profiles(self):
+        left_item = self.left_profiles.currentItem()
+        right_item = self.right_profiles.currentItem()
+        if not left_item or not right_item:
+            return
+        left_id = left_item.data(Qt.ItemDataRole.UserRole)
+        right_id = right_item.data(Qt.ItemDataRole.UserRole)
+
+        left_data = self._read_profile(left_id)
+        right_data = self._read_profile(right_id)
+
+        def extract_lists(data: dict[str, Any]):
+            natives = []
+            for n in data.get("natives", []) or []:
+                if isinstance(n, dict):
+                    path_str = n.get("path") or ""
+                    if path_str:
+                        # Extract just the filename from the path
+                        natives.append(Path(path_str).name)
+            packages = []
+            for p in data.get("packages", []) or []:
+                if isinstance(p, dict):
+                    pid = p.get("id")
+                    if pid:
+                        packages.append(pid)
+            return set(natives), set(packages)
+
+        l_natives, l_packages = extract_lists(left_data)
+        r_natives, r_packages = extract_lists(right_data)
+
+        # Populate UI lists
+        self._fill_list(self.left_natives_list, l_natives)
+        self._fill_list(self.left_packages_list, l_packages)
+        self._fill_list(self.right_natives_list, r_natives)
+        self._fill_list(self.right_packages_list, r_packages)
+
+        # Differences summary
+        added = len(r_natives - l_natives) + len(r_packages - l_packages)
+        removed = len(l_natives - r_natives) + len(l_packages - r_packages)
+        self.added_label.setText(tr("profile_compare_added", count=added))
+        self.removed_label.setText(tr("profile_compare_removed", count=removed))
+
+    def _fill_list(self, widget: QListWidget, items: set[str]):
+        widget.clear()
+        for s in sorted(items):
+            widget.addItem(QListWidgetItem(s))

--- a/src/me3_manager/ui/game_page_components/profile_handler.py
+++ b/src/me3_manager/ui/game_page_components/profile_handler.py
@@ -135,8 +135,11 @@ class ProfileHandler:
         delete_btn = QPushButton(
             QIcon(resource_path("resources/icon/delete.svg")), tr("delete_button")
         )
+        compare_btn = QPushButton(
+            QIcon(resource_path("resources/icon/profiles.svg")), tr("compare_button")
+        )
 
-        for btn in [activate_btn, add_btn, rename_btn, delete_btn]:
+        for btn in [activate_btn, add_btn, rename_btn, delete_btn, compare_btn]:
             btn.setStyleSheet(button_style)
             btn.setIconSize(QSize(20, 20))
 
@@ -144,6 +147,7 @@ class ProfileHandler:
         button_layout.addWidget(add_btn)
         button_layout.addWidget(rename_btn)
         button_layout.addWidget(delete_btn)
+        button_layout.addWidget(compare_btn)
         button_layout.addStretch()
         layout.addLayout(button_layout, 1)
 
@@ -304,12 +308,21 @@ class ProfileHandler:
                 refresh_list()
                 self.game_page.load_mods()
 
+        def on_compare():
+            from me3_manager.ui.dialogs.profile_compare_dialog import (
+                ProfileCompareDialog,
+            )
+
+            dlg = ProfileCompareDialog(self.game_name, self.config_manager, dialog)
+            dlg.exec()
+
         search_bar.textChanged.connect(refresh_list)
         list_widget.currentItemChanged.connect(update_button_states)
         activate_btn.clicked.connect(on_activate)
         add_btn.clicked.connect(on_add)
         rename_btn.clicked.connect(on_rename)
         delete_btn.clicked.connect(on_delete)
+        compare_btn.clicked.connect(on_compare)
 
         refresh_list()
         dialog.exec()


### PR DESCRIPTION
Implement a new dialog that allows users to compare two profiles side-by-side.

This feature provides a clear and intuitive interface for users to see the differences in installed mods ("natives" and "packages") between any two profiles for a given game.

Key changes include:
- A new `ProfileCompareDialog` class that handles the UI and logic for the comparison.
- The dialog is launched from a new "Compare" button in the "Manage Profiles" window.
- The dialog pre-selects the active profile on the left and the next available profile on the right for immediate comparison.
- Displays a summary of added and removed mods between the two selected profiles.