### PR TITLE
Sanitize child process environment to fix Arch readline symbol error

### DIFF
--- a/src/me3_manager/services/steam_service.py
+++ b/src/me3_manager/services/steam_service.py
@@ -120,7 +120,7 @@ class SteamService:
                         prepared,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
-                        env=os.environ.copy(),
+                        env=PlatformUtils.sanitized_env_for_subprocess(),
                     )
                     return True
                 except FileNotFoundError:

--- a/src/me3_manager/ui/game_page_components/game_launcher.py
+++ b/src/me3_manager/ui/game_page_components/game_launcher.py
@@ -141,6 +141,10 @@ class GameLauncher:
         terminal.process.setProcessChannelMode(
             QProcess.ProcessChannelMode.MergedChannels
         )
+        # Sanitize environment to avoid leaking PyInstaller libs to child processes
+        terminal.process.setProcessEnvironment(
+            PlatformUtils.build_qprocess_environment()
+        )
         terminal.process.readyReadStandardOutput.connect(terminal.handle_stdout)
         terminal.process.finished.connect(terminal.process_finished)
         # Use centralized list command prep for QProcess
@@ -168,4 +172,7 @@ class GameLauncher:
         """Launch the game command directly via a subprocess."""
         # Use centralized subprocess preparation
         prepared = PlatformUtils.prepare_command(command_args)
-        subprocess.Popen(prepared)
+        subprocess.Popen(
+            prepared,
+            env=PlatformUtils.sanitized_env_for_subprocess(),
+        )

--- a/src/me3_manager/ui/terminal.py
+++ b/src/me3_manager/ui/terminal.py
@@ -211,6 +211,8 @@ class EmbeddedTerminal(QWidget):
 
         self.process = QProcess(self)
         self.process.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
+        # Sanitize environment to avoid leaking PyInstaller libs to child processes
+        self.process.setProcessEnvironment(PlatformUtils.build_qprocess_environment())
         self.process.readyReadStandardOutput.connect(self.handle_stdout)
         self.process.finished.connect(self.process_finished)
 

--- a/src/me3_manager/utils/command_runner.py
+++ b/src/me3_manager/utils/command_runner.py
@@ -49,7 +49,9 @@ class CommandRunner:
             check=False,
             startupinfo=startupinfo,
             timeout=timeout,
-            env=env,
+            env=(
+                env if env is not None else PlatformUtils.sanitized_env_for_subprocess()
+            ),
             encoding=encoding,
             errors=errors,
         )


### PR DESCRIPTION
- Strip problematic env vars (LD_LIBRARY_PATH, LD_PRELOAD, QT_PLUGIN_PATH, QT_QPA_PLATFORM_PLUGIN_PATH, PYTHONHOME, PYTHONPATH, PYINSTALLER_BOOTLOADER) from all child process launches.
- Add PlatformUtils.sanitized_env_for_subprocess() and build_qprocess_environment() helpers.
- Apply sanitized env to:
  -  QProcess in ui/terminal.py and game_page_components/game_launcher.py
  - subprocess.Popen in game_launcher and SteamService
  - subprocess.run default via CommandRunner.run
- reserve Flatpak host spawning and login-shell behavior on Linux.
- Fixes Arch Linux crash when launching via manager: /usr/bin/bash: symbol lookup error: bssh … undefined symbol: rl_print_keybinding, by aligning launched processes with a clean environment similar to running in a normal terminal.