### PR TITLE
fix(regulation): re-activate using full path; include external packages

### DIFF
--- a/src/me3_manager/core/mod_manager.py
+++ b/src/me3_manager/core/mod_manager.py
@@ -866,18 +866,25 @@ class ImprovedModManager:
 
     def disable_all_regulations(self, game_name: str) -> tuple[bool, str]:
         """
-        Disable regulation.bin across all mods by renaming any active files
-        to regulation.bin.disabled. This leaves no active regulation.
+        Disable regulation.bin across all mods (internal and tracked external)
+        by renaming any active files to regulation.bin.disabled. This leaves
+        no active regulation.
         """
         try:
-            mods_dir = self.config_manager.get_mods_dir(game_name)
-            for folder in mods_dir.iterdir():
-                if not folder.is_dir():
+            # Collect both internal and tracked external package folders
+            candidate_folders = self._candidate_regulation_folders(game_name)
+
+            for folder in candidate_folders:
+                try:
+                    if not folder.is_dir():
+                        continue
+                    regulation_file = folder / "regulation.bin"
+                    disabled_file = folder / "regulation.bin.disabled"
+                    if regulation_file.exists():
+                        regulation_file.rename(disabled_file)
+                except Exception:
+                    # Ignore failures on a single folder and continue
                     continue
-                regulation_file = folder / "regulation.bin"
-                disabled_file = folder / "regulation.bin.disabled"
-                if regulation_file.exists():
-                    regulation_file.rename(disabled_file)
 
             # Even if nothing changed, it's a successful no-op
             return True, "Regulation disabled for all mods"

--- a/src/me3_manager/ui/game_page_components/mod_action_handler.py
+++ b/src/me3_manager/ui/game_page_components/mod_action_handler.py
@@ -116,7 +116,6 @@ class ModActionHandler:
 
     def activate_regulation_mod(self, mod_path: str):
         """Activates the regulation.bin file for a specific mod."""
-        mod_name = Path(mod_path).name
         # If the clicked mod is already the active regulation, interpret the action as disabling all
         mod_info = self.game_page.mod_infos.get(mod_path)
         if getattr(mod_info, "regulation_active", False):
@@ -125,7 +124,7 @@ class ModActionHandler:
             )
         else:
             success, message = self.mod_manager.set_regulation_active(
-                self.game_page.game_name, mod_name
+                self.game_page.game_name, mod_path
             )
 
         if success:


### PR DESCRIPTION
- Pass full mod_path to set_regulation_active to avoid “Mod folder not found”.
- Update disable_all_regulations to handle internal and tracked external packages.