### PR TITLE
fix(mod_manager): Handle unreadable mod folders during scan

### DIFF
--- a/src/me3_manager/core/mod_manager.py
+++ b/src/me3_manager/core/mod_manager.py
@@ -222,11 +222,15 @@ class ImprovedModManager:
             return True
 
         # Check if it contains acceptable subfolders
-        if any(
-            sub.is_dir() and sub.name in self.acceptable_folders
-            for sub in folder.iterdir()
-        ):
-            return True
+        try:
+            if any(
+                sub.is_dir() and sub.name in self.acceptable_folders
+                for sub in folder.iterdir()
+            ):
+                return True
+        except (PermissionError, OSError):
+            # Skip folders we cannot read (e.g., system junctions like AppData)
+            return False
 
         # Check if it has regulation files
         if (folder / "regulation.bin").exists() or (


### PR DESCRIPTION
https://github.com/2Pz/me3-manager/issues/91
- Added error handling for PermissionError and OSError when iterating through folder contents.
- Ensures that folders that cannot be read (e.g., system junctions) are skipped gracefully.
