### PR TITLE
feat(profile): Add savefile choice and apply imported profile options

### DIFF
--- a/resources/translations/ar.json
+++ b/resources/translations/ar.json
@@ -279,6 +279,8 @@
   "name_imported_package_title": "سمّي حزمة المودات المستوردة",
   "name_imported_package_desc": "أدخل اسم لحزمة المودات المستوردة.",
   "importing_from_label": "جاري الاستيراد من: {folder}",
+  "savefile_preference_title": "تفضيل ملف الحفظ",
+  "savefile_preference_message": "البروفايل الحالي يستخدم ملف الحفظ '{current_savefile}'، لكن البروفايل المستورد يستخدم '{imported_savefile}'.\n\nاختر نعم لاستخدام ملف الحفظ المستورد، أو لا للاحتفاظ بالملف الحالي.",
   "import_cancelled_status": "تم إلغاء الاستيراد.",
   "importing_from_status": "جاري الاستيراد من {folder}...",
   "mod_exists_title": "المود موجود",

--- a/resources/translations/en.json
+++ b/resources/translations/en.json
@@ -279,6 +279,8 @@
   "name_imported_package_title": "Name Imported Mod Package",
   "name_imported_package_desc": "Enter a name for the imported package mod(s).",
   "importing_from_label": "Importing from: {folder}",
+  "savefile_preference_title": "Savefile Preference",
+  "savefile_preference_message": "The current profile uses savefile '{current_savefile}', but the imported profile uses '{imported_savefile}'.\n\nSelect Yes to use the imported savefile, or No to keep the current one.",
   "import_cancelled_status": "Import cancelled.",
   "importing_from_status": "Importing from {folder}...",
   "mod_exists_title": "Mod Exists",

--- a/resources/translations/zh.json
+++ b/resources/translations/zh.json
@@ -279,6 +279,8 @@
   "name_imported_package_title": "命名导入的模组包",
   "name_imported_package_desc": "输入导入的包模组的名称。",
   "importing_from_label": "正在从以下位置导入: {folder}",
+  "savefile_preference_title": "存档偏好",
+  "savefile_preference_message": "当前配置使用存档 '{current_savefile}'，而导入的配置使用 '{imported_savefile}'。\n\n选择“是”以使用导入的存档，选择“否”以保留当前存档。",
   "import_cancelled_status": "导入已取消。",
   "importing_from_status": "正在从 {folder} 导入...",
   "mod_exists_title": "模组已存在",


### PR DESCRIPTION
- Prompt to keep current savefile or use imported when they differ during .me3 import.
- Always apply imported profile settings for start_online, disable_arxan, supports, and profileVersion.