### PR TITLE
🚀 Release: Me3 Manager 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 > A comprehensive changelog for the Mod Engine 3 Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.5.0
+**Released:** March 07, 2026
+
+
+### ✨ New Features
+
+- Community Profiles Guide link to remote_links.json ([12b6ce3](https://github.com/2Pz/me3-manager/commit/12b6ce37cb28b6a4dae5e982f915a15a1eb24f6f))
+
+
+
+### 🔧 Bug Fixes
+
+- Use PlatformUtils for reliable external links on Linux `[ui]` ([3f08315](https://github.com/2Pz/me3-manager/commit/3f083153c9be08e051497bd7492007fa278c8daf))
+
+
+
+### 🎨 User Interface
+
+- Simplify custom savefile dialog and update tooltips ([2a63b5f](https://github.com/2Pz/me3-manager/commit/2a63b5ff460412ba6f5b6cd31c3ca0ae8a94c789))
+
+
+
+### Ui
+
+- Implement dynamic remote tutorial links ([e673637](https://github.com/2Pz/me3-manager/commit/e673637748efa24f8680152363d8c9aba59ddcc5))
+
+
+
+---
 ## 📦 Release 1.4.4
 **Released:** March 03, 2026
 
@@ -807,6 +836,7 @@
 
 
 ---
+[1.5.0]: https://github.com/2Pz/me3-manager/compare/1.4.4..1.5.0
 [1.4.4]: https://github.com/2Pz/me3-manager/compare/1.4.3..1.4.4
 [1.4.3]: https://github.com/2Pz/me3-manager/compare/1.4.2..1.4.3
 [1.4.2]: https://github.com/2Pz/me3-manager/compare/1.4.1..1.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "me3-manager"
-version = "1.4.4"
+version = "1.5.0"
 description = "GUI application for Mod engine 3"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "me3-manager"
-version = "1.4.4"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.5.0
**Released:** March 07, 2026


### ✨ New Features

- Community Profiles Guide link to remote_links.json ([12b6ce3](https://github.com/2Pz/me3-manager/commit/12b6ce37cb28b6a4dae5e982f915a15a1eb24f6f))



### 🔧 Bug Fixes

- Use PlatformUtils for reliable external links on Linux `[ui]` ([3f08315](https://github.com/2Pz/me3-manager/commit/3f083153c9be08e051497bd7492007fa278c8daf))



### 🎨 User Interface

- Simplify custom savefile dialog and update tooltips ([2a63b5f](https://github.com/2Pz/me3-manager/commit/2a63b5ff460412ba6f5b6cd31c3ca0ae8a94c789))



### Ui

- Implement dynamic remote tutorial links ([e673637](https://github.com/2Pz/me3-manager/commit/e673637748efa24f8680152363d8c9aba59ddcc5))