### PR TITLE
🚀 Release: Me3 Manager 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 **Released:** June 24, 2026
 
 
+### 🌐 Translations
+
+- Improve Chinese translation text ([#243](https://github.com/2Pz/me3-manager/pull/243)) ([86668e5](https://github.com/2Pz/me3-manager/commit/86668e5))
+
+
 ---
 ## 📦 Release 1.4.6
 **Released:** May 23, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 > A comprehensive changelog for the Mod Engine 3 Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.4.7
+**Released:** June 24, 2026
+
+
+---
 ## 📦 Release 1.4.6
 **Released:** May 23, 2026
 
@@ -883,6 +888,7 @@
 
 
 ---
+[1.4.7]: https://github.com/2Pz/me3-manager/compare/1.4.6..1.4.7
 [1.4.6]: https://github.com/2Pz/me3-manager/compare/1.4.5..1.4.6
 [1.4.5]: https://github.com/2Pz/me3-manager/compare/1.4.4..1.4.5
 [1.4.4]: https://github.com/2Pz/me3-manager/compare/1.4.3..1.4.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "me3-manager"
-version = "1.4.6"
+version = "1.4.7"
 description = "GUI application for Mod engine 3"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "me3-manager"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.4.7
**Released:** June 24, 2026


### 🌐 Translations

- Improve Chinese translation text ([#243](https://github.com/2Pz/me3-manager/pull/243)) ([86668e5](https://github.com/2Pz/me3-manager/commit/86668e5))