### PR TITLE
🚀 Release: Me3 Manager 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 > A comprehensive changelog for the Mod Engine 3 Manager application.
 > All notable changes to this project are documented here.
 
-## 📦 Release 1.4.9
+## 📦 Release 1.5.0
 **Released:** July 17, 2026
 
 
@@ -960,7 +960,7 @@
 
 
 ---
-[1.4.9]: https://github.com/2Pz/me3-manager/compare/1.4.8..1.4.9
+[1.5.0]: https://github.com/2Pz/me3-manager/compare/1.4.8..1.5.0
 [1.4.8]: https://github.com/2Pz/me3-manager/compare/1.4.7..1.4.8
 [1.4.7]: https://github.com/2Pz/me3-manager/compare/1.4.6..1.4.7
 [1.4.6]: https://github.com/2Pz/me3-manager/compare/1.4.5..1.4.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "me3-manager"
-version = "1.4.9"
+version = "1.5.0"
 description = "GUI application for Mod engine 3"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -92,13 +92,13 @@ name = "cx-freeze"
 version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cabarchive", marker = "sys_platform == 'win32'" },
-    { name = "cx-logging", marker = "platform_machine != 'ARM64' and sys_platform == 'win32'" },
-    { name = "filelock", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or sys_platform != 'linux'" },
-    { name = "lief", marker = "sys_platform == 'win32'" },
-    { name = "packaging", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or sys_platform != 'linux'" },
-    { name = "setuptools", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or sys_platform != 'linux'" },
-    { name = "striprtf", marker = "sys_platform == 'win32'" },
+    { name = "cabarchive" },
+    { name = "cx-logging", marker = "platform_machine != 'ARM64'" },
+    { name = "filelock" },
+    { name = "lief" },
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "striprtf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/5b/4b3f55f008c3bc06c211ce8905e11384f7e40c6eb3d63c3fadebf2af3fe3/cx_freeze-8.4.0.tar.gz", hash = "sha256:8e2e332f571529c7b55cc58521add9de222c4a681620a537b1d29c5d17a24041", size = 2994705, upload-time = "2025-08-11T06:41:20.893Z" }
 wheels = [
@@ -156,7 +156,7 @@ wheels = [
 
 [[package]]
 name = "me3-manager"
-version = "1.4.9"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.5.0
**Released:** July 17, 2026


### ✨ New Features

- Improve mod installation responsiveness with cancel support ([135d36b](https://github.com/2Pz/me3-manager/commit/135d36ba45c148c5a15ff7b247b29c6d8c042889))



### 🔧 Bug Fixes

- Explicitly copy OpenSSL DLLs to root on Windows to prevent Applink crashes `[build]` ([d1ca328](https://github.com/2Pz/me3-manager/commit/d1ca32813eb233ffda074a1d8a5da2f891b23515))

- Exclude libxkbcommon and remove problematic plugin path override `[linux]` ([0e48bc5](https://github.com/2Pz/me3-manager/commit/0e48bc5dc53a1f73605a1fb8e169853a455ebfa5))



### 🎨 User Interface

- Centralize game page notification banners ([64c0d1d](https://github.com/2Pz/me3-manager/commit/64c0d1dac6f277f0c39503f22e0138c3837f3a64))

- Clearly list failed mod downloads in the final import report ([64079bb](https://github.com/2Pz/me3-manager/commit/64079bbf153e935d440bd026a9d0838269dd4476))



### ♻️ Code Refactoring

- Extract shared patterns across the codebase to reduce duplication ([f3b0710](https://github.com/2Pz/me3-manager/commit/f3b0710ef23786b490346179d75b39b3a11e1faf))



### 🧹 Maintenance

- Bump project version to 1.4.9 ([ab72621](https://github.com/2Pz/me3-manager/commit/ab726211d21a0b7ec1d708e4ec122153f5cd5808))